### PR TITLE
Removed obsolete uefi packages

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -1,7 +1,3 @@
-#grub-efi-x86_64
-#prebootloader
-#gummiboot
-#refind-efi
 #lib32-glibc
 #lib32-libstdc++5
 #lib32-nouveau-dri


### PR DESCRIPTION
After investigation using arch wiki, i`m sure we don`t need this packages. We have refind-efi added with new archiso config update, and gummiboot is a part of systemd now. prebootloader is obsolete, and grub-efi is unnecessary.
Fixes #8 